### PR TITLE
Add tailnet services proxy with SNI-based routing

### DIFF
--- a/headscale/templates/client-secret-job-rbac.yaml
+++ b/headscale/templates/client-secret-job-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.client.enabled }}
+{{- if or .Values.client.enabled (and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/headscale/templates/create-client-secret-job.yaml
+++ b/headscale/templates/create-client-secret-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.client.enabled }}
+{{- if or .Values.client.enabled (and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0)) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -35,7 +35,6 @@ spec:
           LABEL_SELECTOR="app.kubernetes.io/component=server,app.kubernetes.io/instance=$RELEASE_NAME"
 
           CLIENT_USER=${CLIENT_USER:-headscale-system}
-          SECRET_NAME=${SECRET_NAME:-"$FULLNAME-client-authkey"}
 
           echo "[INFO] Locating a ready headscale pod (timeout ~5m)..."
           HEADSCALE_POD=""
@@ -84,7 +83,10 @@ spec:
             echo "[INFO] No existing preauth keys found for user; nothing to prune."
           fi
 
-          echo "[INFO] Creating preauth key for user '$CLIENT_USER' (id=$USER_ID)..."
+          {{- if .Values.client.enabled }}
+          # --- Client preauth key ---
+          SECRET_NAME="$FULLNAME-client-authkey"
+          echo "[INFO] Creating preauth key for client '$CLIENT_USER' (id=$USER_ID)..."
           AUTH_KEY=""
           for i in 1 2 3 4 5; do
             {{- if gt (len .Values.client.advertiseRoutes) 0 }}
@@ -96,15 +98,15 @@ spec:
             if [ -n "${AUTH_KEY:-}" ]; then
               break
             fi
-            echo "[WARN] Could not obtain preauth key (attempt $i). Retrying in 3s..."
+            echo "[WARN] Could not obtain client preauth key (attempt $i). Retrying in 3s..."
             sleep 3
           done
           if [ -z "${AUTH_KEY:-}" ]; then
-            echo "[ERROR] Failed to extract preauth key after multiple attempts. Last output:" >&2
+            echo "[ERROR] Failed to extract client preauth key after multiple attempts. Last output:" >&2
             echo "$PAK_OUT" >&2
             exit 1
           fi
-          echo "[INFO] Got preauth key (redacted)"
+          echo "[INFO] Got client preauth key (redacted)"
 
           echo "[INFO] Creating or updating secret '$SECRET_NAME'..."
           kubectl create secret generic "$SECRET_NAME" -n "$NAMESPACE" \
@@ -117,4 +119,39 @@ spec:
           else
             echo "[INFO] Client deployment not found; skipping restart."
           fi
+          {{- end }}
+
+          {{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) }}
+          # --- Proxy preauth key ---
+          PROXY_SECRET_NAME="$FULLNAME-proxy-authkey"
+          echo "[INFO] Creating preauth key for tailnet proxy '$CLIENT_USER' (id=$USER_ID)..."
+          PROXY_AUTH_KEY=""
+          for i in 1 2 3 4 5; do
+            PAK_OUT=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -- headscale preauthkeys create -u "$USER_ID" --reusable --ephemeral -o json 2>&1 || true)
+            PROXY_AUTH_KEY=$(printf "%s" "$PAK_OUT" | jq -r '.key // empty' | head -n1)
+            if [ -n "${PROXY_AUTH_KEY:-}" ]; then
+              break
+            fi
+            echo "[WARN] Could not obtain proxy preauth key (attempt $i). Retrying in 3s..."
+            sleep 3
+          done
+          if [ -z "${PROXY_AUTH_KEY:-}" ]; then
+            echo "[ERROR] Failed to extract proxy preauth key after multiple attempts. Last output:" >&2
+            echo "$PAK_OUT" >&2
+            exit 1
+          fi
+          echo "[INFO] Got proxy preauth key (redacted)"
+
+          echo "[INFO] Creating or updating secret '$PROXY_SECRET_NAME'..."
+          kubectl create secret generic "$PROXY_SECRET_NAME" -n "$NAMESPACE" \
+            --from-literal=authkey="$PROXY_AUTH_KEY" \
+            --dry-run=client -o yaml | kubectl apply -f - || { echo "[ERROR] Failed to create/apply secret '$PROXY_SECRET_NAME'" >&2; exit 1; }
+
+          echo "[INFO] Attempting to restart tailnet-proxy deployment (if present)..."
+          if kubectl get deployment "$FULLNAME-tailnet-proxy" -n "$NAMESPACE" >/dev/null 2>&1; then
+            kubectl rollout restart deployment "$FULLNAME-tailnet-proxy" -n "$NAMESPACE"
+          else
+            echo "[INFO] Tailnet-proxy deployment not found; skipping restart."
+          fi
+          {{- end }}
 {{- end }}

--- a/headscale/templates/tailnet-proxy-configmap.yaml
+++ b/headscale/templates/tailnet-proxy-configmap.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "headscale.fullname" . }}-tailnet-proxy
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+      {{- $portMap := dict }}
+      {{- range $svc := .Values.tailnetServices.services }}
+      {{- range $port := $svc.ports }}
+      {{- $key := printf "%d" (int $port.port) }}
+      {{- $entry := dict "svcName" $svc.name "svcHostname" $svc.hostname "portName" $port.name "portPort" $port.port "portTargetPort" ($port.targetPort | default $port.port) "svcTargetHost" $svc.targetHost }}
+      {{- if hasKey $portMap $key }}
+      {{- $_ := set $portMap $key (append (index $portMap $key) $entry) }}
+      {{- else }}
+      {{- $_ := set $portMap $key (list $entry) }}
+      {{- end }}
+      {{- end }}
+      {{- end }}
+      {{- range $portStr := keys $portMap | sortAlpha }}
+      {{- $entries := index $portMap $portStr }}
+      {{- if gt (len $entries) 1 }}
+        - name: tls-passthrough-{{ $portStr }}
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: {{ $portStr }}
+          listener_filters:
+            - name: envoy.filters.listener.tls_inspector
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
+          filter_chains:
+          {{- range $entry := $entries }}
+            - filter_chain_match:
+                server_names:
+                  - "{{ $entry.svcHostname }}"
+              filters:
+                - name: envoy.filters.network.tcp_proxy
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                    stat_prefix: {{ $entry.svcName }}-{{ $entry.portName }}
+                    cluster: {{ $entry.svcName }}-{{ $entry.portName }}
+          {{- end }}
+      {{- else }}
+      {{- $entry := index $entries 0 }}
+        - name: {{ $entry.svcName }}-{{ $entry.portName }}
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: {{ $entry.portPort }}
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.tcp_proxy
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+                    stat_prefix: {{ $entry.svcName }}-{{ $entry.portName }}
+                    cluster: {{ $entry.svcName }}-{{ $entry.portName }}
+      {{- end }}
+      {{- end }}
+      clusters:
+      {{- range $svc := .Values.tailnetServices.services }}
+      {{- range $port := $svc.ports }}
+        - name: {{ $svc.name }}-{{ $port.name }}
+          type: LOGICAL_DNS
+          connect_timeout: 5s
+          dns_refresh_rate: 30s
+          load_assignment:
+            cluster_name: {{ $svc.name }}-{{ $port.name }}
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: {{ $svc.targetHost }}
+                          port_value: {{ $port.targetPort | default $port.port }}
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/headscale/templates/tailnet-proxy-deployment.yaml
+++ b/headscale/templates/tailnet-proxy-deployment.yaml
@@ -1,0 +1,89 @@
+{{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "headscale.fullname" . }}-tailnet-proxy
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "headscale.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tailnet-proxy
+  template:
+    metadata:
+      labels:
+        {{- include "headscale.labels" . | nindent 8 }}
+        app.kubernetes.io/component: tailnet-proxy
+      annotations:
+        checksum/envoy-config: {{ include (print $.Template.BasePath "/tailnet-proxy-configmap.yaml") . | sha256sum }}
+    spec:
+      volumes:
+      - name: dev-net-tun
+        hostPath:
+          path: /dev/net/tun
+          type: CharDevice
+      - name: proxy-auth
+        secret:
+          secretName: {{ include "headscale.fullname" . }}-proxy-authkey
+          optional: true
+      - name: envoy-config
+        configMap:
+          name: {{ include "headscale.fullname" . }}-tailnet-proxy
+      containers:
+      - name: tailscale
+        image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag }}"
+        imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          AUTH_FILE="/etc/proxy-auth/authkey"
+          echo "[tailnet-proxy] Waiting for preauth key at $AUTH_FILE ..."
+          for i in $(seq 1 120); do
+            if [ -s "$AUTH_FILE" ]; then
+              break
+            fi
+            echo "[tailnet-proxy] auth key not present yet ($i/120)"
+            sleep 5
+          done
+
+          echo "[tailnet-proxy] Starting tailscaled"
+          tailscaled &
+
+          if [ -s "$AUTH_FILE" ]; then
+            AUTH_KEY=$(cat "$AUTH_FILE")
+            echo "[tailnet-proxy] Performing tailscale up"
+            tailscale up --authkey="$AUTH_KEY" --hostname={{ .Chart.Name }}-tailnet-proxy --login-server=http://{{ include "headscale.fullname" . }}:8080 \
+              || true
+          else
+            echo "[tailnet-proxy] No preauth key found after timeout; skipping tailscale up for now."
+          fi
+
+          wait $! || true
+          tail -f /dev/null
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+        volumeMounts:
+        - name: dev-net-tun
+          mountPath: /dev/net/tun
+        - name: proxy-auth
+          mountPath: /etc/proxy-auth
+          readOnly: true
+      - name: envoy
+        image: "{{ .Values.tailnetServices.image.repository }}:{{ .Values.tailnetServices.image.tag }}"
+        imagePullPolicy: {{ .Values.tailnetServices.image.pullPolicy }}
+        command:
+        - envoy
+        - -c
+        - /etc/envoy/envoy.yaml
+        volumeMounts:
+        - name: envoy-config
+          mountPath: /etc/envoy
+          readOnly: true
+{{- end }}

--- a/headscale/templates/tailnet-proxy-dns-configmap.yaml
+++ b/headscale/templates/tailnet-proxy-dns-configmap.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "headscale.fullname" . }}-tailnet-dns
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+data:
+  tailnet-services.snippet: |
+    {{- range $svc := .Values.tailnetServices.services }}
+    rewrite name exact {{ $svc.hostname }} {{ include "headscale.fullname" $ }}-ts-{{ $svc.name }}.{{ $.Release.Namespace }}.svc.cluster.local
+    {{- end }}
+{{- end }}

--- a/headscale/templates/tailnet-proxy-pdb.yaml
+++ b/headscale/templates/tailnet-proxy-pdb.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) (.Values.tailnetServices.podDisruptionBudget.enabled | default false) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "headscale.fullname" . }}-tailnet-proxy
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+spec:
+  selector:
+    matchLabels:
+      {{- include "headscale.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tailnet-proxy
+  {{- $pdb := .Values.tailnetServices.podDisruptionBudget }}
+  {{- if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else if hasKey $pdb "maxUnavailable" }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else }}
+  maxUnavailable: 1
+  {{- end }}
+{{- end }}

--- a/headscale/templates/tailnet-proxy-service.yaml
+++ b/headscale/templates/tailnet-proxy-service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.tailnetServices.enabled (gt (len .Values.tailnetServices.services) 0) }}
+{{- range $svc := .Values.tailnetServices.services }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "headscale.fullname" $ }}-ts-{{ $svc.name }}
+  labels:
+    {{- include "headscale.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "headscale.selectorLabels" $ | nindent 4 }}
+    app.kubernetes.io/component: tailnet-proxy
+  ports:
+  {{- range $port := $svc.ports }}
+    - name: {{ $port.name }}
+      port: {{ $port.port }}
+      targetPort: {{ $port.port }}
+      protocol: {{ $port.protocol | default "TCP" }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -196,4 +196,28 @@ client:
       tag: "1.30.2"
       pullPolicy: IfNotPresent
 
-# (UI values defined above; duplicate block removed)
+# Tailnet Services: expose services living on the tailnet as Kubernetes ClusterIP Services.
+# Deploys a single pod running tailscale (for tailnet connectivity) + Envoy (for TCP proxying),
+# with one Kubernetes Service per exposed tailnet service, plus a CoreDNS-compatible ConfigMap
+# for DNS resolution.
+tailnetServices:
+  enabled: false
+  image:
+    repository: envoyproxy/envoy
+    tag: "v1.32-latest"
+    pullPolicy: IfNotPresent
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 1
+  services: []
+    # - name: my-nas                          # unique identifier, used in K8s resource names
+    #   hostname: "mynas.home.local"           # DNS name for CoreDNS rewrite rules (Host/SNI matching)
+    #   targetHost: "100.64.0.5"              # tailnet IP or MagicDNS name
+    #   ports:
+    #     - name: smb                          # port name (used in K8s Service port name)
+    #       port: 445                          # K8s service port & envoy listener port
+    #       targetPort: 445                    # upstream port on tailnet host (defaults to port)
+    #       protocol: TCP                      # TCP (default)
+    #     - name: https
+    #       port: 443
+    #       protocol: TCP


### PR DESCRIPTION
## Summary

- Adds a tailnet services proxy (tailscale + envoy sidecar) that exposes tailnet-hosted services as Kubernetes ClusterIP Services
- Implements SNI-based routing for shared ports: when multiple services use the same port (e.g. two HTTPS services on 443), Envoy uses the TLS inspector to read the SNI from the ClientHello and route to the correct upstream without terminating TLS
- Ports used by only one service keep simple TCP proxy behavior (no TLS inspector overhead)

## What's included

- **Envoy ConfigMap** with port-grouping logic: builds a port map, generates SNI listeners for shared ports and simple TCP proxy listeners for unique ports
- **Proxy Deployment**: tailscale container (tailnet connectivity) + envoy container (TCP proxying)
- **Per-service K8s Services** with CoreDNS rewrite ConfigMap for DNS resolution
- **PDB, RBAC, preauth key Job** integration
- **Smoke test** (`hack/kind-smoke.sh --with-tailnet-services`) covering both SNI and simple listener paths

## How SNI routing works

```
Client → K8s Service (ClusterIP:443) → Envoy listener (port 443)
  ├─ TLS inspector reads SNI from ClientHello
  ├─ SNI "gitlab.example.com" → filter chain → cluster gitlab-https → tailnet 100.64.0.1:443
  └─ SNI "registry.example.com" → filter chain → cluster registry-https → tailnet 100.64.0.2:443
```

## Test plan

- [x] `helm template` with two services sharing port 443 — single SNI listener with two filter chains
- [x] `helm template` with no port overlap — simple TCP proxy listeners, no TLS inspector
- [x] `helm lint` passes
- [x] `hack/kind-smoke.sh --with-tailnet-services --keep` passes all checks
- [x] End-to-end SNI routing verified: same IP:port, different SNI values routed to different backends (confirmed via TLS certificate CN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)