### PR TITLE
Fix client preauthkey expiration

### DIFF
--- a/headscale/Chart.yaml
+++ b/headscale/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/headscale/templates/create-client-secret-job.yaml
+++ b/headscale/templates/create-client-secret-job.yaml
@@ -88,9 +88,9 @@ spec:
           AUTH_KEY=""
           for i in 1 2 3 4 5; do
             {{- if gt (len .Values.client.advertiseRoutes) 0 }}
-            PAK_OUT=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -- headscale preauthkeys create -u "$USER_ID" --reusable --ephemeral --tags tag:in-cluster-client -o json 2>&1 || true)
+            PAK_OUT=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -- headscale preauthkeys create -u "$USER_ID" --reusable --ephemeral --expiration {{ .Values.client.preauthKeyExpiration | default "87600h" }} --tags tag:in-cluster-client -o json 2>&1 || true)
             {{- else }}
-            PAK_OUT=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -- headscale preauthkeys create -u "$USER_ID" --reusable --ephemeral -o json 2>&1 || true)
+            PAK_OUT=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -- headscale preauthkeys create -u "$USER_ID" --reusable --ephemeral --expiration {{ .Values.client.preauthKeyExpiration | default "87600h" }} -o json 2>&1 || true)
             {{- end }}
             AUTH_KEY=$(printf "%s" "$PAK_OUT" | jq -r '.key // empty' | head -n1)
             if [ -n "${AUTH_KEY:-}" ]; then

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -185,6 +185,12 @@ client:
   # Example:
   #   - "10.20.0.0/16"    # specific external subnet
   advertiseRoutes: []
+  # Expiration for the client preauthkey. Headscale defaults to 1h when
+  # omitted, which causes the in-cluster client to lose connectivity once
+  # the key expires.  Set to a long duration (default 87600h ≈ 10 years)
+  # to keep the client connected across restarts.  The key is regenerated
+  # on every helm upgrade anyway, so this is effectively non-expiring.
+  preauthKeyExpiration: "87600h"
   # Pod disruption budget settings for the optional client deployment.
   podDisruptionBudget:
     enabled: true


### PR DESCRIPTION
## Summary

- The `headscale preauthkeys create` command in the hook job did not pass `--expiration`, causing Headscale to use its default of 1 hour
- After the key expires, the in-cluster Tailscale client enters a permanent `authkey expired` loop and can never re-register, breaking subnet route advertisement
- Added `--expiration` flag (configurable via `client.preauthKeyExpiration`, default `87600h` / ~10 years) so keys survive across pod restarts
- The key is regenerated on every `helm upgrade` anyway, so this is effectively non-expiring

## Test plan

- [ ] `helm lint headscale/` passes
- [ ] `helm template` renders `--expiration 87600h` in both the advertiseRoutes and no-routes code paths
- [ ] `hack/kind-smoke.sh --with-client` deploys cleanly
- [ ] After deploy, `headscale preauthkeys list` shows a key with expiration ~10 years out

🤖 Generated with [Claude Code](https://claude.com/claude-code)