### PR TITLE
Update headscale to v0.28.0

### DIFF
--- a/headscale/Chart.yaml
+++ b/headscale/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.27.0"
+appVersion: "0.28.0"

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -6,7 +6,7 @@ image:
   repository: headscale/headscale
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.27.0"
+  tag: "v0.28.0"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
## Summary
- Bumps headscale container image from v0.27.0 to v0.28.0 (latest upstream release)
- Bumps chart version from 0.1.5 to 0.1.6

## Upstream changes (v0.28.0)
- Tags as identity: tags and user ownership are now mutually exclusive
- Smarter map updates: partial updates instead of full network maps
- Pre-authentication key security improvements (bcrypt hashing)
- PreAuthKey CLI uses ID-based operations (--user flag still accepted but no longer required)
- Database migration support removed for pre-0.25.0 databases

## Test plan
- [x] Smoke-tested with `hack/kind-smoke.sh --with-client` on a kind cluster
- [x] All verifications passed: deployment, client, DNS records, policy config

🤖 Generated with [Claude Code](https://claude.com/claude-code)