### PR TITLE
feat(server): allow explicit derp map configuration

### DIFF
--- a/headscale/templates/configmap.yaml
+++ b/headscale/templates/configmap.yaml
@@ -31,6 +31,16 @@ data:
         {{- $_ := set $dns "extra_records_path" $path -}}
       {{- end -}}
     {{- end -}}
+    {{- /* Add derp.paths when a static DERP map is provided */ -}}
+    {{- if .Values.derpMap.enabled -}}
+      {{- if not (hasKey $cfg "derp") -}}
+        {{- $_ := set $cfg "derp" (dict) -}}
+      {{- end -}}
+      {{- $derp := index $cfg "derp" -}}
+      {{- if not (hasKey $derp "paths") -}}
+        {{- $_ := set $derp "paths" (list .Values.derpMap.path) -}}
+      {{- end -}}
+    {{- end -}}
     {{- /* Add policy path when client advertises routes */ -}}
     {{- if and .Values.client.enabled (gt (len .Values.client.advertiseRoutes) 0) -}}
       {{- if not (hasKey $cfg "policy") -}}

--- a/headscale/templates/deployment.yaml
+++ b/headscale/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.derpMap.enabled }}
+        checksum/derp-map: {{ include (print $.Template.BasePath "/derp-map-configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.extraDnsRecords.enabled }}
         checksum/extra-dns: {{ include (print $.Template.BasePath "/extra-dns-configmap.yaml") . | sha256sum }}
         {{- end }}
@@ -70,6 +73,12 @@ spec:
             - name: config
               mountPath: /etc/headscale/config.yaml
               subPath: config.yaml
+            {{- if .Values.derpMap.enabled }}
+            - name: derp-map
+              mountPath: {{ .Values.derpMap.path }}
+              subPath: {{ .Values.derpMap.configMap.key }}
+              readOnly: true
+            {{- end }}
             {{ if .Values.extraDnsRecords.enabled }}
             {{- $extra := .Values.extraDnsRecords -}}
             {{- $dnsConfig := (index .Values.config "dns") | default (dict) -}}
@@ -99,6 +108,18 @@ spec:
         - name: config
           configMap:
             name: {{ include "headscale.fullname" . }}
+        {{- if .Values.derpMap.enabled }}
+        {{- $dm := .Values.derpMap -}}
+        {{- $cmName := "" -}}
+        {{- if $dm.configMap.create -}}
+          {{- $cmName = default (printf "%s-derp-map" (include "headscale.fullname" .)) $dm.configMap.name -}}
+        {{- else -}}
+          {{- $cmName = required "derpMap.configMap.name must be set when derpMap.configMap.create is false" $dm.configMap.name -}}
+        {{- end }}
+        - name: derp-map
+          configMap:
+            name: {{ $cmName }}
+        {{- end }}
         {{ if .Values.extraDnsRecords.enabled }}
         {{- $extra := .Values.extraDnsRecords -}}
         {{- $cmName := "" -}}

--- a/headscale/templates/derp-map-configmap.yaml
+++ b/headscale/templates/derp-map-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.derpMap.enabled .Values.derpMap.configMap.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ default (printf "%s-derp-map" (include "headscale.fullname" .)) .Values.derpMap.configMap.name }}
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+data:
+  {{ .Values.derpMap.configMap.key }}: |
+    {{- toYaml .Values.derpMap.regions | nindent 4 }}
+{{- end }}

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -160,6 +160,16 @@ config:
     urls:
       - https://controlplane.tailscale.com/derpmap/default
 
+# Static DERP map file
+derpMap:
+  enabled: false  # Set to true to mount a custom DERP map and add it to derp.paths.
+  path: /etc/headscale/derp-map.yaml  # Path inside the container for the rendered DERP map file.
+  configMap:
+    create: true  # When true, the chart creates a ConfigMap using the regions map below.
+    name: ""  # Optional override for the ConfigMap name; required when create=false to reference an existing ConfigMap.
+    key: derp-map.yaml  # Key inside the ConfigMap data that stores the DERP map payload.
+  regions: {}  # DERP map content (regions, OmitDefaultRegions, etc.) rendered as YAML.
+
 # Extra DNS records (MagicDNS)
 extraDnsRecords:
   enabled: false  # Set to true to configure dns.extra_records_path and mount the JSON file.


### PR DESCRIPTION
## Add support for static DERP map files

### Motivation

Headscale supports defining custom DERP relay servers via a static DERP map file referenced by `derp.paths` in the server config. Until now, the chart had no way to create and mount this file, forcing users to work around the limitation manually.

### Changes

Adds a new `derpMap` values section (following the same pattern as `extraDnsRecords`):

- **`values.yaml`** — Exposes `derpMap.enabled`, `derpMap.path`, `derpMap.configMap.*`, and `derpMap.regions` for user configuration.
- **`templates/derp-map-configmap.yaml`** *(new)* — Creates a ConfigMap containing the DERP map YAML when `derpMap.configMap.create` is `true`. Supports referencing an externally-managed ConfigMap by setting `create: false` and providing a `name`.
- **`templates/configmap.yaml`** — Automatically injects `derp.paths` into the headscale config when `derpMap.enabled` is `true`, unless the user has already set it explicitly.
- **`templates/deployment.yaml`** — Mounts the DERP map ConfigMap into the container and adds a `checksum/derp-map` pod annotation to trigger rollouts on content changes.
- **`hack/kind-smoke.sh`** — Enables a DERP map in the smoke test values and verifies the rendered config contains `derp.paths`, the correct mount path, and the expected region content in the ConfigMap.

### Usage

```yaml
derpMap:
  enabled: true
  regions:
    OmitDefaultRegions: true
    Regions:
      900:
        RegionID: 900
        RegionCode: myderp
        RegionName: My DERP
        Nodes:
          - Name: myderp
            RegionID: 900
            HostName: derp.example.com
```

To reference an existing ConfigMap instead of having the chart create one:

```yaml
derpMap:
  enabled: true
  configMap:
    create: false
    name: my-existing-derp-map
```

### Validation

- `helm lint` passes
- `helm template --set derpMap.enabled=true` renders the expected ConfigMap, volume, volume mount, config injection, and checksum annotation
- `hack/kind-smoke.sh` updated with DERP map verification checks