### PR TITLE
feat: add extraVolumes and extraVolumeMounts support

### DIFF
--- a/headscale/README.md
+++ b/headscale/README.md
@@ -142,7 +142,7 @@ $ helm install my-release foo-bar/headscale
 | client.image.repository | string | `"tailscale/tailscale"` |  |
 | client.image.tag | string | `"stable"` |  |
 | client.job.cronjob.enabled | bool | `false` |  |
-| client.job.cronjob.schedule | string | `"0 */6 * * *"` |  |
+| client.job.cronjob.schedule | string | `"0 3 1 * *"` |  |
 | client.job.image.pullPolicy | string | `"IfNotPresent"` |  |
 | client.job.image.repository | string | `"alpine/k8s"` |  |
 | client.job.image.tag | string | `"1.30.2"` |  |
@@ -175,6 +175,8 @@ $ helm install my-release foo-bar/headscale
 | extraDnsRecords.enabled | bool | `false` |  |
 | extraDnsRecords.path | string | `"/etc/headscale/extra-dns-records.json"` |  |
 | extraDnsRecords.records | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"headscale/headscale"` |  |

--- a/headscale/templates/deployment.yaml
+++ b/headscale/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
               subPath: {{ $subPath }}
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         {{- if .Values.persistence.enabled }}
         - name: data
@@ -147,6 +150,9 @@ spec:
         - name: policy
           configMap:
             name: {{ $policyCmName }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -235,4 +235,22 @@ client:
       enabled: false
       schedule: "0 3 1 * *"  # First of each month at 03:00 by default
 
+# Extra volumes to add to the Headscale server deployment.
+# Useful for mounting secrets (e.g. OIDC client credentials) or other files.
+# Example:
+#   - name: oidc-client-secret
+#     secret:
+#       secretName: headscale-oidc-credentials
+#       items:
+#         - key: CLIENT_SECRET
+#           path: oidc_client_secret
+extraVolumes: []
+
+# Extra volume mounts to add to the Headscale server container.
+# Example:
+#   - name: oidc-client-secret
+#     mountPath: /etc/headscale/oidc
+#     readOnly: true
+extraVolumeMounts: []
+
 # (UI values defined above; duplicate block removed)


### PR DESCRIPTION
## Summary
- Adds `extraVolumes` and `extraVolumeMounts` values to the Headscale server deployment
- Allows users to mount arbitrary volumes (e.g. Kubernetes Secrets for OIDC client credentials) without needing Kustomize post-renderers
- Includes inline examples in `values.yaml` for OIDC secret mounting

## Test plan
- [x] `helm template` renders correctly with no extra volumes (empty defaults)
- [x] `helm template` renders correctly with extraVolumes/extraVolumeMounts set
- [ ] Deploy with OIDC secret volume to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)