### PR TITLE
feat(client): optional DaemonSet mode for direct tailnet connectivity

### DIFF
--- a/headscale/README.md
+++ b/headscale/README.md
@@ -137,6 +137,7 @@ $ helm install my-release foo-bar/headscale
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | client.advertiseRoutes | list | `[]` |  |
+| client.daemonset | bool | `false` | Run the client as a DaemonSet with hostNetwork, giving every node direct tailnet connectivity. Useful when nodes need to reach tailnet IPs directly (e.g. pulling images from a private registry on the tailnet). |
 | client.enabled | bool | `true` |  |
 | client.image.pullPolicy | string | `"IfNotPresent"` |  |
 | client.image.repository | string | `"tailscale/tailscale"` |  |

--- a/headscale/templates/client-deployment.yaml
+++ b/headscale/templates/client-deployment.yaml
@@ -1,14 +1,17 @@
 {{- if .Values.client.enabled }}
 {{- $hasRoutes := gt (len .Values.client.advertiseRoutes) 0 }}
+{{- $isDaemonSet := .Values.client.daemonset }}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ if $isDaemonSet }}DaemonSet{{ else }}Deployment{{ end }}
 metadata:
   name: {{ include "headscale.fullname" . }}-client
   labels:
     {{- include "headscale.labels" . | nindent 4 }}
     app.kubernetes.io/component: client
 spec:
+  {{- if not $isDaemonSet }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       {{- include "headscale.selectorLabels" . | nindent 6 }}
@@ -20,6 +23,13 @@ spec:
         app.kubernetes.io/component: client
     spec:
       serviceAccountName: {{ include "headscale.fullname" . }}-client
+      {{- if $isDaemonSet }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      {{- end }}
       volumes:
       - name: dev-net-tun
         hostPath:
@@ -33,6 +43,13 @@ spec:
       - name: tailscale
         image: "{{ .Values.client.image.repository }}:{{ .Values.client.image.tag }}"
         imagePullPolicy: {{ .Values.client.image.pullPolicy }}
+        {{- if $isDaemonSet }}
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        {{- end }}
         command:
         - /bin/sh
         - -c
@@ -50,21 +67,32 @@ spec:
             sleep 5
           done
 
-          {{- if $hasRoutes }}
-          # Enable IP forwarding for subnet routing / exit node functionality
+          {{- if or $hasRoutes $isDaemonSet }}
+          # Enable IP forwarding for subnet routing / host network connectivity
           echo "[client] Enabling IP forwarding"
           sysctl -w net.ipv4.ip_forward=1
           sysctl -w net.ipv6.conf.all.forwarding=1
           {{- end }}
 
           echo "[client] Starting tailscaled"
+          {{- if $isDaemonSet }}
+          tailscaled --state=kube:{{ include "headscale.fullname" . }}-client-state-${NODE_NAME} --socket=/var/run/tailscale/tailscaled.sock &
+          {{- else }}
           tailscaled --state=kube:{{ include "headscale.fullname" . }}-client-state --socket=/var/run/tailscale/tailscaled.sock &
+          {{- end }}
 
           # If key exists, perform login; otherwise keep running and allow later manual login
           if [ -s "$AUTH_FILE" ]; then
             AUTH_KEY=$(cat "$AUTH_FILE")
             echo "[client] Performing tailscale up"
+            {{- if $isDaemonSet }}
+            tailscale --socket=/var/run/tailscale/tailscaled.sock up --authkey="$AUTH_KEY" --hostname={{ .Chart.Name }}-client-${NODE_NAME} --login-server=http://{{ include "headscale.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:8080 \
+            {{- else }}
             tailscale --socket=/var/run/tailscale/tailscaled.sock up --authkey="$AUTH_KEY" --hostname={{ .Chart.Name }}-client --login-server=http://{{ include "headscale.fullname" . }}:8080 \
+            {{- end }}
+              {{- if not (kindIs "invalid" .Values.client.acceptDns) }}
+              --accept-dns={{ .Values.client.acceptDns | toString }} \
+              {{- end }}
               {{- if $hasRoutes }}
               --advertise-routes={{ .Values.client.advertiseRoutes | join "," }} \
               {{- end }}
@@ -77,7 +105,7 @@ spec:
           wait $! || true
           tail -f /dev/null
         securityContext:
-          {{- if $hasRoutes }}
+          {{- if or $hasRoutes $isDaemonSet }}
           # Privileged mode required to set sysctl for IP forwarding
           privileged: true
           {{- else }}

--- a/headscale/templates/client-secret-job-rbac.yaml
+++ b/headscale/templates/client-secret-job-rbac.yaml
@@ -24,7 +24,7 @@ rules:
   resources: ["pods/exec"]
   verbs: ["create"]
 - apiGroups: ["apps"]
-  resources: ["deployments"]
+  resources: ["deployments", "daemonsets"]
   verbs: ["get", "list", "watch", "patch", "update"]
 
 ---

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -207,6 +207,10 @@ client:
   # not what you want. Consider advertising only specific external subnets instead.
   # Example:
   #   - "10.20.0.0/16"    # specific external subnet
+  # -- Run the client as a DaemonSet with hostNetwork, giving every node direct tailnet connectivity. Useful when nodes need to reach tailnet IPs directly (e.g. pulling images from a private registry on the tailnet).
+  daemonset: false
+  # -- Override tailscale's --accept-dns flag. When unset, tailscale's default (true) is used. Set to false on clusters without systemd-resolved (e.g. Talos) when running in daemonset mode to prevent node DNS hijacking.
+  # acceptDns: false
   advertiseRoutes: []
   # The client stores its machine key in a Kubernetes Secret (<fullname>-client-state)
   # via tailscaled --state=kube:, keeping a stable node ID across pod restarts


### PR DESCRIPTION
## Summary

- Adds `client.daemonset: false` option to values.yaml
- When enabled, the in-cluster tailscale client runs as a DaemonSet with `hostNetwork: true` instead of a single-replica Deployment
- Every node gets a direct tailscale interface, so cluster workloads and containerd/kubelet can reach tailnet IPs without proxies or DNS overrides
- Each node gets a unique hostname (`headscale-client-<nodename>`) and per-node state secret

## Use case

Clusters that need to pull container images or helm charts from a private registry on the tailnet (e.g. on-prem GitLab). With daemonset mode, `gitlab.example.com` resolves via normal public DNS to a private IP, and every node can route there directly through its local tailscale interface.

## Test plan

- [x] `helm template` with `client.daemonset=false` produces identical output to main (no regression)
- [x] `helm template` with `client.daemonset=true` produces DaemonSet with hostNetwork, privileged, unique hostname
- [x] `hack/kind-smoke.sh --with-client-daemonset` passes all checks
- [x] `hack/kind-smoke.sh` (default, no client) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)