### PR TITLE
Fix TOFU cert fetch: tailscale image has no openssl

### DIFF
--- a/headscale/templates/client-deployment.yaml
+++ b/headscale/templates/client-deployment.yaml
@@ -44,6 +44,10 @@ spec:
         secret:
           secretName: {{ $fullname }}-client-authkey
           optional: true
+      {{- if $modeA }}
+      - name: tofu-certs
+        emptyDir: {}
+      {{- end }}
       {{- if $modeB }}
       - name: headscale-ca
         secret:
@@ -52,6 +56,38 @@ spec:
           - key: ca.crt
             path: ca.crt
           optional: true
+      {{- end }}
+      {{- if $modeA }}
+      initContainers:
+      - name: tofu-cert-fetch
+        image: "{{ .Values.client.internalTls.image.repository }}:{{ .Values.client.internalTls.image.tag }}"
+        imagePullPolicy: {{ .Values.client.internalTls.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -eu
+          apk add --no-cache openssl >/dev/null 2>&1
+          HS_HOST="{{ $fullname }}.{{ .Release.Namespace }}.svc.cluster.local"
+          echo "[tofu] Waiting for TLS sidecar at ${HS_HOST}:443 ..."
+          for i in $(seq 1 120); do
+            if echo | openssl s_client -connect "${HS_HOST}:443" -servername "${HS_HOST}" 2>/dev/null | openssl x509 -noout 2>/dev/null; then
+              echo "[tofu] TLS sidecar is ready"
+              break
+            fi
+            echo "[tofu] TLS sidecar not ready yet ($i/120)"
+            sleep 5
+          done
+          echo | openssl s_client -connect "${HS_HOST}:443" -servername "${HS_HOST}" 2>/dev/null | openssl x509 > /tofu-certs/sidecar.crt 2>/dev/null
+          if [ -s /tofu-certs/sidecar.crt ]; then
+            echo "[tofu] Sidecar TLS certificate saved"
+          else
+            echo "[tofu] ERROR: Could not fetch sidecar TLS certificate" >&2
+            exit 1
+          fi
+        volumeMounts:
+        - name: tofu-certs
+          mountPath: /tofu-certs
       {{- end }}
       containers:
       - name: tailscale
@@ -89,23 +125,13 @@ spec:
           {{- end }}
 
           {{- if $modeA }}
-          # Mode A: TOFU — download the sidecar's self-signed cert
-          HS_HOST="{{ $fullname }}.{{ .Release.Namespace }}.svc.cluster.local"
-          echo "[client] Waiting for TLS sidecar at ${HS_HOST}:443 ..."
-          for i in $(seq 1 60); do
-            if echo | openssl s_client -connect "${HS_HOST}:443" -servername "${HS_HOST}" 2>/dev/null | openssl x509 -noout 2>/dev/null; then
-              break
-            fi
-            echo "[client] TLS sidecar not ready yet ($i/60)"
-            sleep 5
-          done
-          echo | openssl s_client -connect "${HS_HOST}:443" -servername "${HS_HOST}" 2>/dev/null | openssl x509 > /tmp/hs.crt 2>/dev/null || true
-          if [ -s /tmp/hs.crt ]; then
-            cat /etc/ssl/certs/ca-certificates.crt /tmp/hs.crt > /tmp/ca-bundle.crt
+          # Mode A: Trust sidecar cert fetched by init container
+          if [ -s /tofu-certs/sidecar.crt ]; then
+            cat /etc/ssl/certs/ca-certificates.crt /tofu-certs/sidecar.crt > /tmp/ca-bundle.crt
             export SSL_CERT_FILE=/tmp/ca-bundle.crt
             echo "[client] Trusting sidecar TLS certificate (TOFU)"
           else
-            echo "[client] WARNING: Could not fetch sidecar TLS certificate"
+            echo "[client] WARNING: No sidecar certificate found at /tofu-certs/sidecar.crt"
           fi
           {{- end }}
 
@@ -161,6 +187,16 @@ spec:
           # Keep container alive
           wait $! || true
           tail -f /dev/null
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - 'tailscale --socket=/var/run/tailscale/tailscaled.sock status --json | grep -q "BackendState.*Running"'
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
         securityContext:
           {{- if $hasRoutes }}
           # Privileged mode required to set sysctl for IP forwarding
@@ -177,6 +213,11 @@ spec:
         - name: client-auth
           mountPath: /etc/client-auth
           readOnly: true
+        {{- if $modeA }}
+        - name: tofu-certs
+          mountPath: /tofu-certs
+          readOnly: true
+        {{- end }}
         {{- if $modeB }}
         - name: headscale-ca
           mountPath: /etc/headscale-ca


### PR DESCRIPTION
## Summary

- The tailscale container image doesn't ship `openssl`, so the inline TOFU cert download in Mode A silently failed (`|| true`)
- Moves cert fetching to an **init container** (`tofu-cert-fetch`) using `nginx:alpine` which has openssl
- The tailscale container reads the fetched cert from a shared emptyDir volume — no openssl needed
- Adds a **readiness probe** on the client container (`tailscale status` BackendState check)
- Tightens smoke test: TOFU trust message and init container completion are now hard failures

## Why the smoke test didn't catch it before

The `openssl` command failure was silenced by `|| true`. Tailscale's initial login still succeeded (the noise protocol handles first-connect differently from reconnects), so the client state secret appeared and the test passed. The TOFU message check was only a WARN. The real breakage only manifests on **reconnects**, which the smoke test doesn't exercise.

## Test plan

- [x] `helm template` renders cleanly for all mode combinations
- [x] Smoke test `--with-tls-sidecar` passes with init container fetching cert
- [x] Init container logs show `Sidecar TLS certificate saved`
- [x] Client logs show `Trusting sidecar TLS certificate (TOFU)`
- [x] Client reaches `Running` BackendState (readiness probe passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)