### PR TITLE
Fix unnecessary privileged mode in daemonset mode

### DIFF
--- a/headscale/templates/client-deployment.yaml
+++ b/headscale/templates/client-deployment.yaml
@@ -198,8 +198,9 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 30
         securityContext:
-          {{- if $hasRoutes }}
+          {{- if and $hasRoutes (not $isDaemonSet) }}
           # Privileged mode required to set sysctl for IP forwarding
+          # (DaemonSet mode uses hostNetwork and skips the sysctl init container)
           privileged: true
           {{- else }}
           capabilities:


### PR DESCRIPTION
## Summary
- Client container was granted `privileged: true` whenever `advertiseRoutes` was set, even in DaemonSet mode
- DaemonSet mode uses `hostNetwork` and skips the sysctl init container, so privileged is not needed
- Changed condition from `if $hasRoutes` to `if $hasRoutes AND NOT $isDaemonSet`
- In daemonset mode with routes, the container now gets `NET_ADMIN`/`NET_RAW` capabilities instead of full privileged access

## Test plan
- [x] `helm template --set client.daemonset=true --set client.advertiseRoutes[0]=10.0.0.0/8` → `NET_ADMIN`/`NET_RAW` (no privileged)
- [x] `helm template --set client.daemonset=false --set client.advertiseRoutes[0]=10.0.0.0/8` → `privileged: true` (unchanged)
- [x] `helm lint` and default `helm template` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)