### PR TITLE
Add optional policy hot-reload sidecar

### DIFF
--- a/docs/plans/2026-03-05-policy-hot-reload-design.md
+++ b/docs/plans/2026-03-05-policy-hot-reload-design.md
@@ -1,0 +1,44 @@
+# Policy Hot-Reload Sidecar
+
+Related: PR #7 (tekulvw/improvements) — policy hot-reload concept originated there.
+
+## Problem
+
+When ACL policy ConfigMaps are updated, the headscale server pod must be restarted to pick up changes. Users with Stakater Reloader or similar tools can handle this externally, but users without such tools have no built-in option.
+
+## Design
+
+Add an optional `kiwigrid/k8s-sidecar` as a native sidecar (restartable init container) that watches for labeled ConfigMaps and syncs them into the pod filesystem. Headscale detects file changes and reloads policy automatically.
+
+### Values
+
+```yaml
+policy:
+  hotReload:
+    enabled: false
+    image:
+      repository: kiwigrid/k8s-sidecar
+      tag: "1.30.3"
+      pullPolicy: IfNotPresent
+```
+
+### Behavior when enabled
+
+1. Sidecar watches ConfigMaps labeled `headscale-policy: "true"` via `METHOD: WATCH`
+2. Policy ConfigMap gets the `headscale-policy: "true"` label
+3. Policy volume switches from direct ConfigMap mount (subPath) to emptyDir populated by sidecar
+4. Policy path becomes `/etc/headscale/policy/policy.json` (directory mount instead of file mount)
+5. Role/RoleBinding added for main SA to `list/get/watch` ConfigMaps
+
+### Behavior when disabled (default)
+
+No changes from current behavior. Policy is mounted as a standard ConfigMap volume.
+
+### Files touched
+
+- `values.yaml` — new `policy.hotReload` section
+- `values.schema.json` — schema for new fields
+- `deployment.yaml` — conditional sidecar + volume switch
+- `policy-configmap.yaml` — conditional label
+- `serviceaccount.yaml` — conditional RBAC
+- `configmap.yaml` — conditional policy path adjustment

--- a/hack/kind-smoke.sh
+++ b/hack/kind-smoke.sh
@@ -19,6 +19,7 @@ WITH_CLIENT=0
 WITH_CLIENT_DAEMONSET=0
 WITH_TLS=0
 WITH_TLS_SIDECAR=0
+WITH_HOT_RELOAD=0
 
 usage() {
   cat <<EOF
@@ -31,6 +32,7 @@ Options:
   --with-client-daemonset  Enable client in DaemonSet mode with hostNetwork
   --with-tls            Enable TLS Mode B (native TLS, no ingress) with self-signed cert
   --with-tls-sidecar    Enable TLS Mode A (ingress + nginx sidecar) with TOFU
+  --with-hot-reload     Enable policy hot-reload sidecar (k8s-sidecar)
   -h, --help            Show this help message
 
 Environment variables:
@@ -40,6 +42,7 @@ Environment variables:
   WITH_CLIENT_DAEMONSET When set to 1, behaves like --with-client-daemonset
   WITH_TLS              When set to 1, behaves like --with-tls
   WITH_TLS_SIDECAR      When set to 1, behaves like --with-tls-sidecar
+  WITH_HOT_RELOAD       When set to 1, behaves like --with-hot-reload
 EOF
 }
 
@@ -70,6 +73,10 @@ while [[ $# -gt 0 ]]; do
       WITH_TLS_SIDECAR=1
       shift
       ;;
+    --with-hot-reload)
+      WITH_HOT_RELOAD=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -97,6 +104,9 @@ if [[ ${WITH_TLS:-0} -eq 1 ]]; then
 fi
 if [[ ${WITH_TLS_SIDECAR:-0} -eq 1 ]]; then
   WITH_TLS_SIDECAR=1
+fi
+if [[ ${WITH_HOT_RELOAD:-0} -eq 1 ]]; then
+  WITH_HOT_RELOAD=1
 fi
 
 REQUIRED_BINS=(kind kubectl helm)
@@ -140,6 +150,10 @@ trap cleanup EXIT
 
 # TLS flags imply client
 if [[ $WITH_TLS -eq 1 || $WITH_TLS_SIDECAR -eq 1 ]]; then
+  WITH_CLIENT=1
+fi
+# Hot-reload needs a policy ConfigMap; imply --with-client for advertiseRoutes
+if [[ $WITH_HOT_RELOAD -eq 1 ]]; then
   WITH_CLIENT=1
 fi
 
@@ -223,6 +237,14 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
+EOF
+fi
+
+if [[ $WITH_HOT_RELOAD -eq 1 ]]; then
+  cat <<'EOF' >>"$TMP_VALUES"
+policy:
+  hotReload:
+    enabled: true
 EOF
 fi
 
@@ -349,8 +371,13 @@ if [[ $WITH_CLIENT -eq 1 ]]; then
   fi
 
   echo "[verify] Ensuring policy.path is set in headscale config"
-  if ! grep -q 'path: /etc/headscale/policy.json' <<<"$CONFIG_YAML"; then
-    echo "[ERROR] policy.path not found in config.yaml" >&2
+  if [[ $WITH_HOT_RELOAD -eq 1 ]]; then
+    EXPECTED_POLICY_PATH="/etc/headscale/policy/policy.json"
+  else
+    EXPECTED_POLICY_PATH="/etc/headscale/policy.json"
+  fi
+  if ! grep -q "path: $EXPECTED_POLICY_PATH" <<<"$CONFIG_YAML"; then
+    echo "[ERROR] Expected policy.path '$EXPECTED_POLICY_PATH' not found in config.yaml" >&2
     exit 1
   fi
 fi
@@ -570,6 +597,64 @@ if [[ $WITH_TLS_SIDECAR -eq 1 ]]; then
     echo "[WARN] Client state secret not found; TOFU TLS connection may not have completed yet"
     echo "[verify:tls-sidecar] Dumping client pod logs for debugging:"
     kubectl logs "$CLIENT_POD" -n headscale --tail=30 2>/dev/null || true
+  fi
+fi
+
+if [[ $WITH_HOT_RELOAD -eq 1 ]]; then
+  echo "[verify:hot-reload] Ensuring policy-sync sidecar is running in server pod"
+  SERVER_POD=$(kubectl get pods -n headscale -l app.kubernetes.io/component=server -o jsonpath='{.items[0].metadata.name}')
+  INIT_CONTAINERS=$(kubectl get pod "$SERVER_POD" -n headscale -o jsonpath='{.spec.initContainers[*].name}')
+  if echo "$INIT_CONTAINERS" | grep -q 'policy-sync'; then
+    echo "[verify:hot-reload] policy-sync sidecar container present"
+  else
+    echo "[ERROR] policy-sync sidecar not found in server pod (initContainers: $INIT_CONTAINERS)" >&2
+    exit 1
+  fi
+
+  echo "[verify:hot-reload] Ensuring policy-watcher RBAC resources exist"
+  if ! kubectl get role headscale-policy-watcher -n headscale >/dev/null 2>&1; then
+    echo "[ERROR] Role 'headscale-policy-watcher' not found" >&2
+    exit 1
+  fi
+  if ! kubectl get rolebinding headscale-policy-watcher -n headscale >/dev/null 2>&1; then
+    echo "[ERROR] RoleBinding 'headscale-policy-watcher' not found" >&2
+    exit 1
+  fi
+
+  echo "[verify:hot-reload] Ensuring policy ConfigMap has headscale-policy label"
+  POLICY_LABEL=$(kubectl get configmap headscale-policy -n headscale -o jsonpath='{.metadata.labels.headscale-policy}')
+  if [[ "$POLICY_LABEL" != "true" ]]; then
+    echo "[ERROR] Policy ConfigMap missing headscale-policy=true label (got: '$POLICY_LABEL')" >&2
+    exit 1
+  fi
+
+  echo "[verify:hot-reload] Ensuring headscale config uses directory-based policy path"
+  CONFIG_YAML=$(kubectl get configmap headscale -n headscale -o jsonpath='{.data.config\.yaml}')
+  if ! grep -q 'path: /etc/headscale/policy/policy.json' <<<"$CONFIG_YAML"; then
+    echo "[ERROR] policy.path should be /etc/headscale/policy/policy.json for hot-reload mode" >&2
+    echo "[ERROR] Got: $(grep 'path:' <<<"$CONFIG_YAML" | head -3)" >&2
+    exit 1
+  fi
+
+  echo "[verify:hot-reload] Ensuring policy volume is emptyDir (not ConfigMap)"
+  VOLUME_TYPE=$(kubectl get pod "$SERVER_POD" -n headscale -o jsonpath='{.spec.volumes[?(@.name=="policy")].emptyDir}')
+  if [[ -z "$VOLUME_TYPE" ]]; then
+    echo "[ERROR] policy volume is not emptyDir — sidecar won't be able to write" >&2
+    exit 1
+  fi
+
+  echo "[verify:hot-reload] Waiting for policy-sync sidecar to populate policy file"
+  for _ in $(seq 1 30); do
+    if kubectl exec "$SERVER_POD" -n headscale -c policy-sync -- test -f /etc/headscale/policy/policy.json 2>/dev/null; then
+      echo "[verify:hot-reload] Policy file found at /etc/headscale/policy/policy.json"
+      break
+    fi
+    sleep 2
+  done
+  if ! kubectl exec "$SERVER_POD" -n headscale -c policy-sync -- test -f /etc/headscale/policy/policy.json 2>/dev/null; then
+    echo "[ERROR] policy-sync sidecar did not populate /etc/headscale/policy/policy.json" >&2
+    kubectl logs "$SERVER_POD" -n headscale -c policy-sync --tail=20 2>/dev/null || true
+    exit 1
   fi
 fi
 

--- a/headscale/templates/configmap.yaml
+++ b/headscale/templates/configmap.yaml
@@ -57,8 +57,13 @@ data:
         {{- $_ := set $cfg "policy" (dict) -}}
       {{- end -}}
       {{- $policy := index $cfg "policy" -}}
-      {{- $policyPath := ternary .Values.policy.path "/etc/headscale/policy.json" .Values.policy.enabled -}}
-      {{- $_ := set $policy "path" $policyPath -}}
+      {{- $hotReload := and $needsPolicy .Values.policy.hotReload.enabled -}}
+      {{- if $hotReload -}}
+        {{- $_ := set $policy "path" "/etc/headscale/policy/policy.json" -}}
+      {{- else -}}
+        {{- $policyPath := ternary .Values.policy.path "/etc/headscale/policy.json" .Values.policy.enabled -}}
+        {{- $_ := set $policy "path" $policyPath -}}
+      {{- end -}}
     {{- end -}}
     {{- toYaml $cfg | nindent 4 }}
 {{- end }}

--- a/headscale/templates/deployment.yaml
+++ b/headscale/templates/deployment.yaml
@@ -2,6 +2,8 @@
 {{- $tlsSecret := .Values.tls.secretName | default "" -}}
 {{- $modeA := and .Values.client.enabled .Values.ingress.enabled -}}
 {{- $modeB := and (not .Values.ingress.enabled) (ne $tlsSecret "") -}}
+{{- $needsPolicy := or .Values.policy.enabled (and .Values.client.enabled (gt (len .Values.client.advertiseRoutes) 0)) -}}
+{{- $hotReload := and $needsPolicy .Values.policy.hotReload.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,7 +28,7 @@ spec:
         {{- if .Values.extraDnsRecords.enabled }}
         checksum/extra-dns: {{ include (print $.Template.BasePath "/extra-dns-configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if or .Values.policy.enabled (and .Values.client.enabled (gt (len .Values.client.advertiseRoutes) 0)) }}
+        {{- if and $needsPolicy (not $hotReload) }}
         checksum/policy: {{ include (print $.Template.BasePath "/policy-configmap.yaml") . | sha256sum }}
         {{- end }}
         {{- if $modeA }}
@@ -49,8 +51,9 @@ spec:
       serviceAccountName: {{ include "headscale.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if $modeA }}
+      {{- if or $modeA $hotReload }}
       initContainers:
+        {{- if $modeA }}
         - name: generate-internal-tls
           image: "{{ .Values.client.internalTls.image.repository }}:{{ .Values.client.internalTls.image.tag }}"
           imagePullPolicy: {{ .Values.client.internalTls.image.pullPolicy }}
@@ -66,6 +69,27 @@ spec:
           volumeMounts:
             - name: internal-tls-certs
               mountPath: /certs
+        {{- end }}
+        {{- if $hotReload }}
+        - name: policy-sync
+          image: "{{ .Values.policy.hotReload.image.repository }}:{{ .Values.policy.hotReload.image.tag }}"
+          imagePullPolicy: {{ .Values.policy.hotReload.image.pullPolicy }}
+          restartPolicy: Always
+          env:
+            - name: LABEL
+              value: "headscale-policy"
+            - name: LABEL_VALUE
+              value: "true"
+            - name: FOLDER
+              value: /etc/headscale/policy
+            - name: RESOURCE
+              value: configmap
+            - name: METHOD
+              value: WATCH
+          volumeMounts:
+            - name: policy
+              mountPath: /etc/headscale/policy
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -138,13 +162,19 @@ spec:
               subPath: {{ default "extra-dns-records.json" .Values.extraDnsRecords.configMap.key }}
               readOnly: true
             {{- end }}
-            {{- if or .Values.policy.enabled (and .Values.client.enabled (gt (len .Values.client.advertiseRoutes) 0)) }}
+            {{- if $needsPolicy }}
+            {{- if $hotReload }}
+            - name: policy
+              mountPath: /etc/headscale/policy
+              readOnly: true
+            {{- else }}
             {{- $mountPath := ternary .Values.policy.path "/etc/headscale/policy.json" .Values.policy.enabled }}
             {{- $subPath := ternary (.Values.policy.configMap.key | default "policy.json") "policy.json" .Values.policy.enabled }}
             - name: policy
               mountPath: {{ $mountPath }}
               subPath: {{ $subPath }}
               readOnly: true
+            {{- end }}
             {{- end }}
             {{- with .Values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
@@ -214,7 +244,11 @@ spec:
           configMap:
             name: {{ $cmName }}
         {{- end }}
-        {{- if or .Values.policy.enabled (and .Values.client.enabled (gt (len .Values.client.advertiseRoutes) 0)) }}
+        {{- if $needsPolicy }}
+        {{- if $hotReload }}
+        - name: policy
+          emptyDir: {}
+        {{- else }}
         {{- $policyCmName := "" -}}
         {{- if and .Values.policy.enabled (not .Values.policy.configMap.create) -}}
           {{- $policyCmName = required "policy.configMap.name must be set when policy.configMap.create is false" .Values.policy.configMap.name -}}
@@ -224,6 +258,7 @@ spec:
         - name: policy
           configMap:
             name: {{ $policyCmName }}
+        {{- end }}
         {{- end }}
         {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/headscale/templates/policy-configmap.yaml
+++ b/headscale/templates/policy-configmap.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ include "headscale.fullname" . }}-policy
   labels:
     {{- include "headscale.labels" . | nindent 4 }}
+    {{- if .Values.policy.hotReload.enabled }}
+    headscale-policy: "true"
+    {{- end }}
 data:
   {{ .Values.policy.configMap.key | default "policy.json" }}: |
     {{- if $policyCreate }}

--- a/headscale/templates/serviceaccount.yaml
+++ b/headscale/templates/serviceaccount.yaml
@@ -11,3 +11,31 @@ metadata:
   {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}
+{{- if .Values.policy.hotReload.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "headscale.fullname" . }}-policy-watcher
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["list", "get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "headscale.fullname" . }}-policy-watcher
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "headscale.fullname" . }}-policy-watcher
+subjects:
+- kind: ServiceAccount
+  name: {{ include "headscale.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/headscale/values.schema.json
+++ b/headscale/values.schema.json
@@ -279,7 +279,23 @@
             "key": { "type": "string" }
           }
         },
-        "content": { "type": "object" }
+        "content": { "type": "object" },
+        "hotReload": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" },
+                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+              }
+            }
+          }
+        }
       }
     },
     "client": {

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -224,6 +224,14 @@ policy:
   # Merged with auto-generated in-cluster client entries when client.advertiseRoutes is set.
   # See https://headscale.net/ref/acls/ for the policy format.
   content: {}
+  # Hot-reload sidecar: watches the policy ConfigMap and syncs changes into the pod
+  # without requiring a restart. Disable if you already use Stakater Reloader or similar.
+  hotReload:
+    enabled: false
+    image:
+      repository: kiwigrid/k8s-sidecar
+      tag: "1.30.3"
+      pullPolicy: IfNotPresent
 
 client:
   # -- Enable or disable the tailscale client container.


### PR DESCRIPTION
## Summary

- Adds an optional `kiwigrid/k8s-sidecar` as a native sidecar (restartable init container) to the headscale server deployment
- When `policy.hotReload.enabled` is true, ACL policy ConfigMap changes are synced into the pod without requiring a restart
- Disabled by default — users with Stakater Reloader or similar tools can continue using their existing setup

Inspired by the policy hot-reload concept in #7.

## Changes

- `values.yaml` / `values.schema.json` — new `policy.hotReload` section with configurable image
- `deployment.yaml` — conditional sidecar init container, policy volume switches from ConfigMap to emptyDir when hot-reload is on, policy checksum annotation skipped (sidecar handles updates)
- `policy-configmap.yaml` — conditional `headscale-policy: "true"` label for sidecar discovery
- `serviceaccount.yaml` — conditional Role/RoleBinding granting ConfigMap list/get/watch
- `configmap.yaml` — policy path adjusts to `/etc/headscale/policy/policy.json` when hot-reload is on

## Configuration

```yaml
policy:
  enabled: true
  hotReload:
    enabled: true
    image:
      repository: kiwigrid/k8s-sidecar
      tag: "1.30.3"
      pullPolicy: IfNotPresent
```

## Test plan

- [x] `helm lint` passes with default values
- [x] `helm lint` passes with `policy.hotReload.enabled=true`
- [x] Template renders sidecar, RBAC, and label only when hot-reload is enabled
- [x] Template renders standard ConfigMap mount when hot-reload is disabled
- [x] Works with both `policy.enabled=true` and `client.advertiseRoutes` paths
- [x] Kind smoke test (`--with-hot-reload`): sidecar running, RBAC created, label applied, policy file synced by sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)