### PR TITLE
Add forbidden node name renamer CronJob

### DIFF
--- a/headscale/README.md
+++ b/headscale/README.md
@@ -239,6 +239,7 @@ $ helm install my-release foo-bar/headscale
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | client.acceptDns | string | `"unset"` | Override accept-dns flag. In daemonset mode this rewrites the host /etc/resolv.conf. On nodes without split-DNS (e.g. Talos) this breaks cluster DNS. Set to false unless your nodes use systemd-resolved. |
+| client.acceptRoutes | string | `"unset"` | Override accept-routes flag. When true, the client accepts subnet routes advertised by other nodes on the tailnet. Defaults to tailscale's built-in default (false) when left as "unset". |
 | client.advertiseRoutes | list | `[]` | Routes to advertise to the Tailscale network. When configured, IP forwarding is enabled and the client acts as a subnet router. WARNING: Using 0.0.0.0/0 or ::/0 (exit node mode) will also expose all Kubernetes pods and services to clients using this exit node. |
 | client.daemonset | bool | `false` | Run the client as a DaemonSet with hostNetwork, giving every node direct tailnet connectivity. Useful when nodes need to reach tailnet IPs directly (e.g. pulling images from a private registry on the tailnet). WARNING: DaemonSet mode uses hostNetwork and runs privileged on every node, modifying the host network stack. Combined with accept-dns (on by default), this can replace the node's DNS resolver and break cluster DNS on distributions without split-DNS support (e.g. Talos Linux). See client.acceptDns. |
 | client.enabled | bool | `true` | Enable or disable the tailscale client container. |
@@ -282,6 +283,12 @@ $ helm install my-release foo-bar/headscale
 | extraDnsRecords.records | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |
+| forbiddenNodeNames.enabled | bool | `false` |  |
+| forbiddenNodeNames.job.image.pullPolicy | string | `"IfNotPresent"` |  |
+| forbiddenNodeNames.job.image.repository | string | `"alpine/k8s"` |  |
+| forbiddenNodeNames.job.image.tag | string | `"1.30.2"` |  |
+| forbiddenNodeNames.names[0] | string | `"localhost"` |  |
+| forbiddenNodeNames.schedule | string | `"*/15 * * * *"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"headscale/headscale"` |  |

--- a/headscale/templates/forbidden-node-names-cronjob.yaml
+++ b/headscale/templates/forbidden-node-names-cronjob.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.forbiddenNodeNames.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "headscale.fullname" . }}-rename-forbidden-nodes
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.forbiddenNodeNames.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      activeDeadlineSeconds: 300
+      template:
+        spec:
+          serviceAccountName: {{ include "headscale.fullname" . }}-forbidden-names-job
+          restartPolicy: OnFailure
+          volumes:
+          - name: job-script
+            configMap:
+              name: {{ include "headscale.fullname" . }}-forbidden-names-script
+              defaultMode: 0755
+          containers:
+          - name: rename-forbidden-nodes
+            image: "{{ .Values.forbiddenNodeNames.job.image.repository }}:{{ .Values.forbiddenNodeNames.job.image.tag }}"
+            imagePullPolicy: {{ .Values.forbiddenNodeNames.job.image.pullPolicy }}
+            command: ["/scripts/rename-forbidden-nodes.sh"]
+            volumeMounts:
+            - name: job-script
+              mountPath: /scripts
+              readOnly: true
+{{- end }}

--- a/headscale/templates/forbidden-node-names-rbac.yaml
+++ b/headscale/templates/forbidden-node-names-rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.forbiddenNodeNames.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "headscale.fullname" . }}-forbidden-names-job
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "headscale.fullname" . }}-forbidden-names-job
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/exec"]
+  verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "headscale.fullname" . }}-forbidden-names-job
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "headscale.fullname" . }}-forbidden-names-job
+subjects:
+- kind: ServiceAccount
+  name: {{ include "headscale.fullname" . }}-forbidden-names-job
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/headscale/templates/forbidden-node-names-script-configmap.yaml
+++ b/headscale/templates/forbidden-node-names-script-configmap.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.forbiddenNodeNames.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "headscale.fullname" . }}-forbidden-names-script
+  labels:
+    {{- include "headscale.labels" . | nindent 4 }}
+data:
+  rename-forbidden-nodes.sh: |
+    #!/bin/sh
+    # Renames nodes whose hostname matches a forbidden name.
+    # Appends the node ID to make the new name unique:
+    #   localhost -> localhost-12345
+    set -eu
+    apk add --no-cache jq >/dev/null 2>&1 || { echo "[ERROR] Failed to install jq via apk" >&2; exit 1; }
+
+    NAMESPACE="{{ .Release.Namespace }}"
+    RELEASE_NAME="{{ .Release.Name }}"
+    LABEL_SELECTOR="app.kubernetes.io/component=server,app.kubernetes.io/instance=$RELEASE_NAME"
+
+    FORBIDDEN_NAMES="{{ join " " .Values.forbiddenNodeNames.names }}"
+
+    # --- Step 1: Find ready headscale pod ---
+    echo "[INFO] Locating a ready headscale pod..."
+    HEADSCALE_POD=""
+    for i in $(seq 1 30); do
+      CANDIDATE=$(kubectl get pods -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | head -n 1)
+      if [ -n "$CANDIDATE" ]; then
+        if kubectl wait --for=condition=ready "pod/$CANDIDATE" -n "$NAMESPACE" --timeout=5s >/dev/null 2>&1; then
+          HEADSCALE_POD="$CANDIDATE"
+          break
+        fi
+      fi
+      echo "[INFO] Waiting for a ready pod... ($i/30)"
+      sleep 5
+    done
+    if [ -z "${HEADSCALE_POD:-}" ]; then
+      echo "[ERROR] No ready headscale pod found within timeout."
+      exit 1
+    fi
+    echo "[INFO] Using pod: $HEADSCALE_POD"
+
+    # --- Step 2: List all nodes ---
+    NODES_JSON=$(kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -c {{ $.Chart.Name }} -- headscale nodes list -o json 2>/dev/null || printf '[]')
+
+    RENAMED=0
+    # --- Step 3: Check each node against forbidden names ---
+    printf "%s" "$NODES_JSON" | jq -r '.[] | "\(.id) \(.given_name)"' | while read -r NODE_ID NODE_NAME; do
+      [ -n "$NODE_ID" ] || continue
+      for FORBIDDEN in $FORBIDDEN_NAMES; do
+        if [ "$NODE_NAME" = "$FORBIDDEN" ]; then
+          NEW_NAME="${FORBIDDEN}-${NODE_ID}"
+          echo "[INFO] Renaming node $NODE_ID from '$NODE_NAME' to '$NEW_NAME'"
+          kubectl exec -n "$NAMESPACE" "$HEADSCALE_POD" -c {{ $.Chart.Name }} -- headscale nodes rename -i "$NODE_ID" "$NEW_NAME" || {
+            echo "[WARN] Failed to rename node $NODE_ID"
+          }
+          RENAMED=$((RENAMED + 1))
+        fi
+      done
+    done
+
+    echo "[INFO] Done. Renamed nodes with forbidden hostnames."
+{{- end }}

--- a/headscale/values.schema.json
+++ b/headscale/values.schema.json
@@ -354,6 +354,33 @@
         }
       }
     },
+    "forbiddenNodeNames": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "schedule": { "type": "string" },
+        "names": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "job": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "image": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" },
+                "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+              }
+            }
+          }
+        }
+      }
+    },
     "extraVolumes": {
       "type": "array",
       "items": { "type": "object" }

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -270,6 +270,9 @@ client:
 # Forbidden node name renamer
 # Periodically renames nodes that registered with forbidden hostnames
 # (e.g. Android clients that default to "localhost") to prevent DNS conflicts.
+# NOTE: This is a workaround for a limitation in Headscale/Tailscale clients.
+# Should Headscale gain native support for rejecting or renaming nodes with
+# forbidden hostnames, this feature will be removed without hesitation.
 forbiddenNodeNames:
   enabled: false
   schedule: "*/15 * * * *" # Every 15 minutes

--- a/headscale/values.yaml
+++ b/headscale/values.yaml
@@ -267,6 +267,21 @@ client:
       enabled: false
       schedule: "0 3 1 * *" # First of each month at 03:00 by default
 
+# Forbidden node name renamer
+# Periodically renames nodes that registered with forbidden hostnames
+# (e.g. Android clients that default to "localhost") to prevent DNS conflicts.
+forbiddenNodeNames:
+  enabled: false
+  schedule: "*/15 * * * *" # Every 15 minutes
+  # List of hostnames that should be renamed when detected.
+  names:
+    - localhost
+  job:
+    image:
+      repository: alpine/k8s
+      tag: "1.30.2"
+      pullPolicy: IfNotPresent
+
 # Extra volumes to add to the Headscale server deployment.
 # Useful for mounting secrets (e.g. OIDC client credentials) or other files.
 # Example:


### PR DESCRIPTION
## Summary

- Adds an opt-in CronJob (`forbiddenNodeNames.enabled: true`) that periodically renames nodes registered with forbidden hostnames (default: `localhost`)
- Android Tailscale clients default to hostname "localhost", which breaks DNS when search domains like `search .kpv.vpn` are in play — `localhost` resolves to the Android device's tailnet IP instead of `127.0.0.1`
- Renamed nodes get `<original-name>-<node-id>` (e.g. `localhost-12345`) — unique and preserves origin for debugging
- Independent RBAC — works regardless of whether the in-cluster client is enabled

## Configuration

```yaml
forbiddenNodeNames:
  enabled: true
  schedule: "*/15 * * * *"
  names:
    - localhost
```

## Test plan

- [ ] `helm template` with `forbiddenNodeNames.enabled=false` (default) produces no forbidden-names resources
- [ ] `helm template` with `forbiddenNodeNames.enabled=true` renders CronJob, ConfigMap, ServiceAccount, Role, RoleBinding
- [ ] Deploy and register an Android client — verify it gets renamed within the schedule interval
- [ ] Verify adding custom names to the list works (e.g. `names: [localhost, android]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)